### PR TITLE
Potential improvements for sampler

### DIFF
--- a/esp32-spa/inputs/esp32-spa.h
+++ b/esp32-spa/inputs/esp32-spa.h
@@ -703,15 +703,13 @@ class HotTubDisplaySensor : public esphome::Component, public esphome::sensor::S
 
     // Record start and exit critical to minimize time interrupts are disabled
     uint32_t start_ccount = now_ccount;
-    portEXIT_CRITICAL_ISR(&spinlock_);
 
     // Busy-wait using cycle count to let the data line settle (more accurate than counting NOPs)
     while ((get_cycle_count() - start_ccount) < SAMPLE_DELAY_CYCLES) {
-      asm volatile ("nop");
+      __asm__ __volatile__("nop");    // noop, and keep compiler from optimizing out
     }
 
-    // Re-enter critical briefly to sample DATA and update shared state
-    portENTER_CRITICAL_ISR(&spinlock_);
+    // sample DATA and update shared state
     bool bit = gpio_get_level((gpio_num_t)DATA_PIN);
 
     shift_reg = (shift_reg << 1) | static_cast<uint32_t>(bit);

--- a/esp32-spa/inputs/esp32-spa.h
+++ b/esp32-spa/inputs/esp32-spa.h
@@ -702,7 +702,7 @@ class HotTubDisplaySensor : public esphome::Component, public esphome::sensor::S
     last_clock_ccount = now_ccount;
 
     // Record start and exit critical to minimize time interrupts are disabled
-    uint32_t start_ccount = now_ccount;
+    uint32_t start_ccount = get_cycle_count();  // timing: just single instruction delay
 
     // Busy-wait using cycle count to let the data line settle (more accurate than counting NOPs)
     while ((get_cycle_count() - start_ccount) < SAMPLE_DELAY_CYCLES) {


### PR DESCRIPTION
Kinda minor-ish, but three things here:

1) AI noticed that if another interrupt happens during the busy-wait cycle, the sampler could miss stuff.  Since 240 cycles isn't very long for other things to wait, it might be better to just leave spinlock alone.

2) Aggressive compiler settings could null out your noop.  This should bypass it.

3) start_ccount could be variable length depending on the code above.  If you want it to be stable length, not a big penalty to just call get_cycle_count()